### PR TITLE
Fix Set Power to stay On (or Off) if scene sends command and box is already in the correct state

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,13 +108,20 @@ DirectvSTBAccessory.prototype = {
         var that = this;
 		switch(type) {
 			case "power":
-				remote.processKey('power', that.clientAddr, function(err, response) {
-					if (err) {
-						that.log('Unable to change DTV location %s power state!', that.location);
-						callback(new Error("STB Process Power Error."), false);
-						return;
+				remote.getMode(that.clientAddr, function (err, response) {
+					if (err) { response.mode= "1"; }
+					if (parseInt(response.mode) === parseInt(value ? 1 : 0)) {
+						remote.processKey('power', that.clientAddr, function(err, response) {
+							if (err) {
+								that.log('Unable to change DTV location %s power state!', that.location);
+								callback(new Error("STB Process Power Error."), false);
+								return;
+							} else {
+								that.log('DTV location %s power state is now: %s', that.location, (value) ? 'ON' : 'OFF');
+								callback();
+							}
+						});
 					} else {
-						that.log('DTV location %s power state is now: %s', that.location, (value) ? 'ON' : 'OFF');
 						callback();
 					}
 				});


### PR DESCRIPTION
Still have not looked into my other 2 issues yet (not using channel scenes at the moment), but I just recently got an 'Ambient Light' for my TV and setup a 'Watch TV' scene which should turn on the main DIRECTV box and the 'Ambient Light'.

Without this fix, the `setPower` was just a toggle, so if DIRECTV was already on (but my Ambient Light was not), setting the 'Watch TV' scene would actually turn off the DIRECTV box even though the scene says turn it On. This PR fixes that.