### PR TITLE
Fix #14 Crash on loading in Home

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,10 @@ DirectvSTBAccessory.prototype = {
 						remote.getTuned(that.clientAddr, function (err, response) {
 							if (!err) {
 								that.log.debug('DTV location %s current channel is %d', that.location, parseInt(response.major));
-								callback(null, parseInt(response.major));
+							try{callback(null, parseInt(response.major));}
+							catch(Exception){
+								//Do Nothing
+							}
 							} else {
 								that.log.debug('Unable to call for current channel at DTV location %s.', that.location);
 								callback(null, parseInt("0"));


### PR DESCRIPTION
fixes a crash that occurs when you've set scenes with Eve using the Eve app.  Anytime you load homekit it crashes when you open the app and go to a page that has a directv.